### PR TITLE
add sidebar block support

### DIFF
--- a/bootstrap-docs.conf
+++ b/bootstrap-docs.conf
@@ -60,6 +60,13 @@ small=<small{1? class="{1}"}>|</small>
 |
 </section>
 
+[sidebarblock]
+<div class="sidebarblock well{role? {role}}{unbreakable-option? unbreakable}"{id? id="{id}"}>
+<div class="content">
+<div class="title">{title}</div>
+|
+</div></div>
+
 [sect0]
 <section{id? id="{id}"}>
   <div class="page-header">

--- a/examples/base-css-book.asciidoc
+++ b/examples/base-css-book.asciidoc
@@ -422,6 +422,62 @@ NOTE: Be sure to keep code within `<pre>` tags as close to the left as possible;
 
 You may optionally add the `.pre-scrollable` class which will set a max-height of 350px and provide a y-axis scrollbar.
 
+== Sidebar block
+
+====
+.An Example Sidebar
+****
+Any AsciiDoc SectionBody element (apart from
+SidebarBlocks) can be placed inside a sidebar.
+****
+====
+
+You may also used the attribute `role` with values *well-small* or *well-large*
+to control padding and rounded corners.
+
+With `role` set to *well-small* value
+
+====
+.An Example Sidebar
+[role="well-small"]
+****
+Any AsciiDoc SectionBody element (apart from
+SidebarBlocks) can be placed inside a sidebar.
+****
+====
+
+[options="linenums"]
+----
+.An Example Sidebar
+[role="well-small"]
+****
+Any AsciiDoc SectionBody element (apart from
+SidebarBlocks) can be placed inside a sidebar.
+****
+----
+
+With `role` set to *well-large* value
+
+====
+.An Example Sidebar
+[role="well-large"]
+****
+Any AsciiDoc SectionBody element (apart from
+SidebarBlocks) can be placed inside a sidebar.
+****
+====
+
+[options="linenums"]
+----
+.An Example Sidebar
+[role="well-large"]
+****
+Any AsciiDoc SectionBody element (apart from
+SidebarBlocks) can be placed inside a sidebar.
+****
+----
+
+
 = Tables
 
 == Default styles


### PR DESCRIPTION
Related to GH-2 issue I've opened, here is my proposal to add support for asciidoc sidebar block support.

You also need to add a bit of CSS in  bootstrap/docs/assets/css/docs.css, to improve render of sidebar block title

```
div.title {
    color: #5A5A5A;
    font-weight: bold;
    margin-bottom: 0.5em;
}
```

Here is the online version of examples/base-css-book.asciidoc file modified to demonstrate the new feature :  
http://laurent-laville.org/asciidoc/bootsrap-backend-issues/base-css-book-sidebarblock.html#sidebar_block

Enjoy !
- Laurent 
